### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/NetToolBox.AspNet/NetToolBox.AspNet.csproj
+++ b/src/NetToolBox.AspNet/NetToolBox.AspNet.csproj
@@ -2,7 +2,15 @@
   <Import Project="..\..\version.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup>
     <Description>Helper Functions for .NET core</Description>
     <PackageProjectUrl>https://github.com/npnelson/NETToolBox</PackageProjectUrl>

--- a/src/NetToolBox.Core/NetToolBox.Core.csproj
+++ b/src/NetToolBox.Core/NetToolBox.Core.csproj
@@ -2,7 +2,15 @@
   <Import Project="..\..\version.props" />
   <PropertyGroup>   
     <TargetFramework>netstandard2.0</TargetFramework>  
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup>   
     <Description>Helper Functions for .NET core</Description>
     <PackageProjectUrl>https://github.com/npnelson/NETToolBox</PackageProjectUrl>

--- a/src/NetToolBox.Dapper/NetToolBox.Dapper.csproj
+++ b/src/NetToolBox.Dapper/NetToolBox.Dapper.csproj
@@ -2,7 +2,15 @@
   <Import Project="..\..\version.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />

--- a/src/NetToolBox.DependencyInjection/NetToolBox.DependencyInjection.csproj
+++ b/src/NetToolBox.DependencyInjection/NetToolBox.DependencyInjection.csproj
@@ -2,7 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>  
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />

--- a/src/NetToolBox.Queueing/NetToolBox.Queueing.csproj
+++ b/src/NetToolBox.Queueing/NetToolBox.Queueing.csproj
@@ -2,7 +2,15 @@
   <Import Project="..\..\version.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup>  
     <Description>Helper Functions for Azure Service Bus Queueing based on NETStandard</Description>
     <PackageProjectUrl>https://github.com/npnelson/NETToolBox</PackageProjectUrl>

--- a/src/NetToolBox.TPLDataflow/NetToolBox.TPLDataflow.csproj
+++ b/src/NetToolBox.TPLDataflow/NetToolBox.TPLDataflow.csproj
@@ -2,7 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
